### PR TITLE
Fix broken check in lfp_mkostemp

### DIFF
--- a/src/lib/stdlib.c
+++ b/src/lib/stdlib.c
@@ -79,7 +79,7 @@ lfp_mkostemp(char *template, int flags)
     SYSCHECK(EINVAL, len < 6 || template[0] != '/');
 
     char *x_start = _valid_template_p(template, len);
-    SYSCHECK(EINVAL, x_start != NULL);
+    SYSCHECK(EINVAL, x_start == NULL);
 
     int randfd = lfp_open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     SYSGUARD(randfd);


### PR DESCRIPTION
This went unnoticed because until a3f1a9b2d64dcb lfp_mkstemp was using
mkostemp instead of lfp_mkostemp
