### PR TITLE
Support for DragonFly BSD

### DIFF
--- a/src/lib/sendfile.c
+++ b/src/lib/sendfile.c
@@ -27,7 +27,7 @@
 #if defined(HAVE_SENDFILE)
 # if defined(__linux__)
 #  include <sys/sendfile.h>
-# elif defined(__FreeBSD__)
+# elif defined(__FreeBSD__) || defined(__DragonFly__)
 #  include <sys/types.h>
 #  include <sys/socket.h>
 #  include <sys/uio.h>
@@ -48,6 +48,8 @@ lfp_sendfile(int out_fd, int in_fd, off_t offset, size_t nbytes)
     return (ssize_t) sendfile(out_fd, in_fd, &off, nbytes);
 # elif defined(__FreeBSD__)
     return (ssize_t) sendfile(in_fd, out_fd, offset, nbytes, NULL, NULL, SF_MNOWAIT);
+# elif defined(__DragonFly__)
+    return (ssize_t) sendfile(in_fd, out_fd, offset, nbytes, NULL, NULL, 0);
 # elif defined(__APPLE__)
     off_t len = nbytes;
     return (ssize_t) sendfile(in_fd, out_fd, offset, &len, NULL, 0);

--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -24,7 +24,7 @@
 
 #include <lfp/signal.h>
 
-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
+#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 # include <sys/signalvar.h>
 #endif
 


### PR DESCRIPTION
DragonFly BSD is a fork of FreeBSD. This is a small patch which allows libfixposix to work on this OS.
