### PR TITLE
directly asdf loadable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 configure
 config.h.in*
 Makefile.in
+*~
+#*

--- a/lfp.lisp
+++ b/lfp.lisp
@@ -1,0 +1,7 @@
+
+(defpackage :libfixposix (:export :libfixposix))
+
+(cffi:define-foreign-library libfixposix
+  (t (:default #.(cl:merge-pathnames
+                  "src/lib/.libs/libfixposix.so"
+                  cl:*compile-file-pathname*))))

--- a/libfixposix.asd
+++ b/libfixposix.asd
@@ -4,12 +4,15 @@
   :author "Masataro Asai"
   :mailto "guicho2.71828@gmail.com"
   :license "MIT"
-  :components ((:module :build
+  :depends-on (:cffi)
+  :components ((:module "."
                 :perform
                 (compile-op (o c)
-                            (run-shell-command "../configure")
-                            (run-shell-command "make")))))
-
-(defmethod perform :before ((op compile-op) (c (eql (find-system 'libfixposix))))
-  (run-shell-command "autoreconf -i -f"))
-
+                            (flet ((sh (string)
+                                     (run-program string
+                                                  :output *standard-output*
+                                                  :error-output *error-output*)))
+                              (sh "autoreconf -i -f")
+                              (sh "./configure")
+                              (sh "make"))))
+               (:file "lfp" :depends-on ("."))))

--- a/libfixposix.asd
+++ b/libfixposix.asd
@@ -1,0 +1,15 @@
+(in-package :asdf-user)
+(defsystem libfixposix
+  :version "0.1"
+  :author "Masataro Asai"
+  :mailto "guicho2.71828@gmail.com"
+  :license "MIT"
+  :components ((:module :build
+                :perform
+                (compile-op (o c)
+                            (run-shell-command "../configure")
+                            (run-shell-command "make")))))
+
+(defmethod perform :before ((op compile-op) (c (eql (find-system 'libfixposix))))
+  (run-shell-command "autoreconf -i -f"))
+


### PR DESCRIPTION
An attempt to make libfixposix quicklisp loadable... alpha level and hackish.
Quicklisp seems, at least for me, updated more frequently, and is more appropriate than apt-get.
Bundling a prebuilt binary (in a separate branch) is also an option.
I'd appreciate it if you provide some review.
