### PR TITLE
fix lfp_clearenv implementation

### DIFF
--- a/src/lib/unistd.c
+++ b/src/lib/unistd.c
@@ -86,12 +86,12 @@ _lfp_copy_environ(void)
     char **env = lfp_get_environ();
     if (env == NULL) return NULL;
 
-    int len = 1;
+    size_t len = 1;
     for(char **var = env; *var != NULL; var++) {
         ++len;
     }
     char **copy_env = calloc(len, sizeof(char*));
-    memcpy(copy_env, env, len);
+    memcpy(copy_env, env, len * sizeof(char *));
 
     return copy_env;
 }

--- a/src/lib/unistd.c
+++ b/src/lib/unistd.c
@@ -108,6 +108,7 @@ lfp_clearenv(void)
 
     for(char **var = env; *var != NULL; var++) {
         char *tmp = strdup(*var);
+        if (tmp == NULL) return -1;
         char *eql = strchr(tmp, '=');
         if (eql == NULL) {
             free(tmp);


### PR DESCRIPTION
clang complained that

```
src/lib/unistd.c:100:19: warning: expression which evaluates to zero treated as a null pointer constant of type 'char *' [-Wnon-literal-null-conversion]
            eql = '\0';
                  ^~~~
```
this causes unsetenv to be called always with NULL.  Furthermore, even
with this fixed, since `var' is incremented at every step, clearenv ends
up clearing only *half* of envp.  unsetenv(3) moves the pointers around,
so after a call, *var already points to the next item in env (or a NULL
pointer), incrementing it means we're skipping half of the entries!