### PR TITLE
use mkostemp(3) from libc if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ dnl Checks for non-standard headers
 AC_CHECK_HEADER([sys/signalfd.h])
 
 dnl Checks for functions
-AC_CHECK_FUNCS([__xpg_strerror_r strnlen strndup clearenv])
+AC_CHECK_FUNCS([__xpg_strerror_r strnlen strndup clearenv mkostemp])
 LFP_REQUIRE_FUNCS([strtok_r])
 LFP_SEARCH_LIBS([socket], [socket nsl])
 AC_CHECK_FUNCS([accept4 pipe2 sendfile pselect ptsname_r])


### PR DESCRIPTION
hello :)

just as per title, if `mkostemp` is available use it.  `flags` can't contain `O_RDWR` otherwise mkostemp(3) fails.  An alternative way would be to unset O_RDWR in lfp_mkostemp when calling libc' mkostemp.