### PR TITLE
Implement umask and rlimit in lfp_spawn

### DIFF
--- a/src/include/lfp/spawn.h
+++ b/src/include/lfp/spawn.h
@@ -33,6 +33,7 @@ LFP_BEGIN_DECLS
 #include <lfp/signal.h>
 
 #include <inttypes.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -61,6 +62,9 @@ int lfp_spawn_file_actions_adddup2(lfp_spawn_file_actions_t *file_actions,
 
 int lfp_spawn_file_actions_addkeep(lfp_spawn_file_actions_t *file_actions,
                                    int fd);
+
+int lfp_spawn_file_actions_setrlimit(lfp_spawn_file_actions_t *file_actions,
+                                   int resource, const struct rlimit *rlim);
 
 typedef struct {
     uint32_t flags;

--- a/src/include/lfp/spawn.h
+++ b/src/include/lfp/spawn.h
@@ -33,6 +33,7 @@ LFP_BEGIN_DECLS
 #include <lfp/signal.h>
 
 #include <inttypes.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 
 typedef struct {
@@ -70,6 +71,7 @@ typedef struct {
     gid_t    gid;
     char    *chdir_path;
     char    *pts_path;
+    mode_t   umask;
 } lfp_spawnattr_t;
 
 typedef enum {
@@ -93,6 +95,8 @@ typedef enum {
 #define LFP_SPAWN_SETCTTY       ( 1 << 8 )
         LFP_SPAWN_USEVFORK      = 1 << 9,
 #define LFP_SPAWN_USEVFORK      ( 1 << 9 )
+        LFP_SPAWN_SETUMASK      = 1 << 10,
+#define LFP_SPAWN_SETUMASK      ( 1 << 10 )
 } lfp_spawnattr_flags;
 
 int lfp_spawnattr_init(lfp_spawnattr_t *attr);
@@ -123,6 +127,9 @@ int lfp_spawnattr_setuid(lfp_spawnattr_t *attr, const uid_t uid);
 
 int lfp_spawnattr_getgid(lfp_spawnattr_t *attr, gid_t *gid);
 int lfp_spawnattr_setgid(lfp_spawnattr_t *attr, const gid_t gid);
+
+int lfp_spawnattr_getumask(lfp_spawnattr_t *attr, mode_t *umask);
+int lfp_spawnattr_setumask(lfp_spawnattr_t *attr, const mode_t umask);
 
 int lfp_spawn(pid_t *restrict pid,
               const char *restrict path,

--- a/src/include/lfp/spawn.h
+++ b/src/include/lfp/spawn.h
@@ -64,7 +64,7 @@ int lfp_spawn_file_actions_addkeep(lfp_spawn_file_actions_t *file_actions,
                                    int fd);
 
 int lfp_spawn_file_actions_setrlimit(lfp_spawn_file_actions_t *file_actions,
-                                   int resource, const struct rlimit *rlim);
+                                     int resource, const struct rlimit *rlim);
 
 typedef struct {
     uint32_t flags;

--- a/src/lib/spawnattr.c
+++ b/src/lib/spawnattr.c
@@ -220,7 +220,23 @@ lfp_spawnattr_setgid(lfp_spawnattr_t *attr, const gid_t gid)
     attr->gid = gid;
     return 0;
 }
-
+
+DSO_PUBLIC int
+lfp_spawnattr_getumask(lfp_spawnattr_t *attr, mode_t *umask)
+{
+    SYSCHECK(EINVAL, attr == NULL || umask == NULL);
+    *umask = attr->umask;
+    return 0;
+}
+
+DSO_PUBLIC int
+lfp_spawnattr_setumask(lfp_spawnattr_t *attr, const mode_t umask)
+{
+    SYSCHECK(EINVAL, attr == NULL);
+    attr->flags |= LFP_SPAWN_SETUMASK;
+    attr->umask = umask;
+    return 0;
+}
 
 int lfp_spawn_apply_attributes(const lfp_spawnattr_t *attr)
 {
@@ -314,6 +330,9 @@ int lfp_spawn_apply_attributes(const lfp_spawnattr_t *attr)
 #endif
             goto error_return;
         }
+
+    if (attr->flags & LFP_SPAWN_SETUMASK)
+        umask(attr->umask); // always success
 
     return 0;
   error_return:


### PR DESCRIPTION
Triggered by https://github.com/jruby/jruby/issues/6552 this implements setumask and setrlimit for lfp_spawn

I did refactor the internal file actions struct to be a tagged union, but if you'd prefer to stay linear I can undo that.

I also considered the more ffi-friendly signature `(lfp_spawn_file_actions_t *file_actions, int resource, rlim_t cur, rlim_t max)` but as much as I like that as an end-user, I ended up going with the more standard `struct rlimit*` signature here

Fixes #28 
Fixes #27 